### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/masaminh/SlackIncomingWebhook/security/code-scanning/3](https://github.com/masaminh/SlackIncomingWebhook/security/code-scanning/3)

To fix the problem, explicitly declare least-privilege `GITHUB_TOKEN` permissions for the `test` job. Since this job only needs to read the repository contents (for checkout and analysis) and uses `GITHUB_TOKEN` for SonarCloud, `contents: read` is an appropriate minimal scope; no write scopes appear necessary. We do not need to change existing behavior of any steps.

Concretely, in `.github/workflows/build-and-deploy.yaml`, add a `permissions` block under the `test` job definition, parallel to `runs-on`. For example, between line 11 (`runs-on: ubuntu-latest`) and line 12 (`steps:`), add:

```yaml
    permissions:
      contents: read
```

No additional imports or definitions are required; this is purely a YAML configuration change within the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
